### PR TITLE
Add basic Tkinter GUI and macOS packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Nature RSS GUI
+
+该项目原本提供命令行脚本以抓取 Nature 等期刊的 RSS 内容并存储到 SQLite。新增的 `gui_app.py` 提供了一个基于 Tkinter 的简单图形界面，方便在 macOS 上运行和查看最新文章。
+
+## 使用方法
+1. 安装依赖（Python 3 自带 Tkinter，无需额外安装）并确保配置好 `config.json` 以及数据库路径。
+2. 运行 GUI：
+   ```bash
+   python gui_app.py
+   ```
+3. 点击 **“抓取最新”** 按钮可执行 RSS 抓取流程；左侧列表显示数据库中最新文章，选中可在下方查看标题与链接。
+
+## 打包到 macOS 应用
+可以使用 [PyInstaller](https://pyinstaller.org) 将界面打包为独立应用：
+```bash
+pip install pyinstaller
+pyinstaller --windowed --onefile gui_app.py
+```
+生成的可执行文件位于 `dist/` 目录，可直接在 Mac 上运行。

--- a/gui_app.py
+++ b/gui_app.py
@@ -1,0 +1,69 @@
+import os
+import json
+from tkinter import Tk, ttk, Listbox, Text, END, messagebox
+
+import rss_fetch_store
+from rss_common import db_connect
+
+CONFIG_PATH = os.getenv("PIPELINE_CONFIG", "config.json")
+
+articles = []
+
+
+def fetch_latest():
+    try:
+        rss_fetch_store.main()
+        messagebox.showinfo("完成", "已抓取最新 RSS 数据")
+        refresh_articles()
+    except Exception as e:
+        messagebox.showerror("错误", str(e))
+
+
+def get_latest(limit=50):
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    conn = db_connect(cfg.get("db", "./rss_state.db"))
+    cur = conn.cursor()
+    rows = list(
+        cur.execute(
+            "SELECT title_en, article_url FROM articles ORDER BY datetime(fetched_at) DESC LIMIT ?",
+            (limit,),
+        )
+    )
+    conn.close()
+    return rows
+
+
+def refresh_articles():
+    global articles
+    articles = get_latest()
+    listbox.delete(0, END)
+    for title, _ in articles:
+        listbox.insert(END, title)
+
+
+def on_select(event):
+    if not listbox.curselection():
+        return
+    idx = listbox.curselection()[0]
+    title, url = articles[idx]
+    text.delete("1.0", END)
+    text.insert(END, f"{title}\n{url}")
+
+
+root = Tk()
+root.title("Nature RSS GUI")
+
+btn_fetch = ttk.Button(root, text="抓取最新", command=fetch_latest)
+btn_fetch.pack(pady=5)
+
+listbox = Listbox(root)
+listbox.pack(fill="both", expand=True)
+listbox.bind("<<ListboxSelect>>", on_select)
+
+text = Text(root, height=5)
+text.pack(fill="x")
+
+refresh_articles()
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- Add `gui_app.py`, a Tkinter interface to fetch RSS updates and browse recent articles
- Document how to run the GUI and package it for macOS in new README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6af0e24f88326a4f59b7881f28a38